### PR TITLE
Postinit - copy the jumpstarter client config

### DIFF
--- a/.devfile.yaml
+++ b/.devfile.yaml
@@ -23,4 +23,12 @@ components:
                 value: "/home/user/.kube/config"
               - name: JMP_CLIENT_CONFIG_HOME
                 value: "/home/user/.jumpstarter"
-
+commands:
+  - id: copy-jmp-client
+    exec:
+      component: runtime
+      commandLine: "bash ./cp_jmp_client.sh"
+      workingDir: ${PROJECT_SOURCE}
+events:
+  postStart:
+    - copy-jmp-client

--- a/cp_jmp_client.sh
+++ b/cp_jmp_client.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+USER=$(cat /projects/.code-workspace | grep '"username":' | sed 's/.*: "\(.*\)".*/\1/')
+HOST=$(cat /projects/.code-workspace | grep '"host":' | sed 's/.*: "\(.*\)".*/\1/')
+
+DEST=$USER@$HOST
+KEY=$HOME/autosd-dev.pem
+
+ssh -i $KEY $DEST -t 'mkdir -p ~/.jumpstarter/clients/' && scp -i $KEY /home/user/.jumpstarter/clients/default.yaml $DEST:~/.jumpstarter/clients/
+


### PR DESCRIPTION
This PR will copy the jumpstarter client config from the local devspace to the remote VM after the devspaces starts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added an automated process that copies a configuration file to a remote server each time the development container starts. This helps ensure the necessary client file is always available on the remote environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->